### PR TITLE
Enable initializing syngcn with user-defined embeddings

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -46,7 +46,7 @@ Source code for [ACL 2019](http://acl2019.org) paper: [Incorporating Syntactic a
 - Execute `make` to compile the C++ code for creating batches.
 - To start training run:
   ```shell
-  python syngcn.py -name test_embeddings -dump -maxsentlen <max_sentence_length in your data.txt> -maxdeplen <max_dependency_length in your data.txt> -gpu 0
+  python syngcn.py -name test_embeddings -dump -maxsentlen <max_sentence_length in your data.txt> -maxdeplen <max_dependency_length in your data.txt> -embed_dim 300 -gpu 0
   ```
 
 * The trained embeddings will be stored in `./embeddings` directory with the provided name `test_embeddings` .

--- a/helper.py
+++ b/helper.py
@@ -126,7 +126,14 @@ def getEmbeddings(embed_loc, wrd_list, embed_dims):
 	wrd2embed = {}
 	for line in open(embed_loc, encoding='utf-8', errors='ignore'):
 		data = line.strip().split(' ')
-		wrd, embed = data[0], data[1:]
+
+		# wrd, embed = data[0], data[1:]
+
+		# Some words may be separated by space (telephone numbers, for example).
+		# It's more robust to load data as follows.
+		embed = data[-1*embed_dims: ] 
+		wrd   = ' '.join(data[: -1*embed_dims])
+
 		embed = list(map(float, embed))
 		wrd2embed[wrd] = embed
 

--- a/syngcn.py
+++ b/syngcn.py
@@ -27,7 +27,7 @@ class SynGCN(Model):
 		"""
 		self.lib.reset()
 		while True:
-			max_len = 0;
+			# max_len = 0; unused variable
 			eph_ovr = self.lib.getBatch(self.edges_addr, self.wrds_addr, self.negs_addr, self.samp_addr, self.elen_addr, self.wlen_addr, 
 					  	    self.p.win_size, self.p.num_neg, self.p.batch_size, ctypes.c_float(self.p.sample))
 			if eph_ovr == 1: break
@@ -61,7 +61,7 @@ class SynGCN(Model):
 		self.vocab_size     = len(self.voc2id)
 		self.wrd_list	    = [self.id2voc[i] for i in range(self.vocab_size)]
 
-		self.de2id	    = read_mappings('./data/de2id.txt');    self.de2id   = {k:      int(v) for k, v in self.de2id.items()}; 
+		self.de2id	    = read_mappings('./data/de2id.txt');    self.de2id   = {k:      int(v) for k, v in self.de2id.items()}
 		self.num_deLabel    = len(self.de2id)
 
 		# Calculating rejection probability
@@ -321,8 +321,14 @@ class SynGCN(Model):
 		"""
 
 		with tf.variable_scope('Embed_mat'):
+
+			if self.p.embed_loc: # if target embeddings for initialization is assigned
+				embed_init		= getEmbeddings(self.p.embed_loc, [self.id2voc[i] for i in range(len(self.voc2id))], self.p.embed_dim)
+			else:
+				embed_init		= tf.contrib.layers.xavier_initializer()
+
 			_wrd_embed 	    = tf.get_variable('embed_matrix',   [self.vocab_size,  self.p.embed_dim], \
-							initializer=tf.contrib.layers.xavier_initializer(), regularizer=self.regularizer)
+							initializer=embed_init, regularizer=self.regularizer)
 			wrd_pad             = tf.Variable(tf.zeros([1, self.p.embed_dim]), trainable=False)
 			self.embed_matrix   = tf.concat([_wrd_embed, wrd_pad], axis=0)
 

--- a/syngcn.py
+++ b/syngcn.py
@@ -322,13 +322,16 @@ class SynGCN(Model):
 
 		with tf.variable_scope('Embed_mat'):
 
-			if self.p.embed_loc: # if target embeddings for initialization is assigned
+			# when target embeddings for initialization is assigned
+			if self.p.embed_loc: 
 				embed_init		= getEmbeddings(self.p.embed_loc, [self.id2voc[i] for i in range(len(self.voc2id))], self.p.embed_dim)
+				_wrd_embed 	    = tf.get_variable('embed_matrix', \
+							initializer=embed_init, regularizer=self.regularizer)
 			else:
 				embed_init		= tf.contrib.layers.xavier_initializer()
-
-			_wrd_embed 	    = tf.get_variable('embed_matrix',   [self.vocab_size,  self.p.embed_dim], \
+				_wrd_embed 	    = tf.get_variable('embed_matrix',   [self.vocab_size,  self.p.embed_dim], \
 							initializer=embed_init, regularizer=self.regularizer)
+
 			wrd_pad             = tf.Variable(tf.zeros([1, self.p.embed_dim]), trainable=False)
 			self.embed_matrix   = tf.concat([_wrd_embed, wrd_pad], axis=0)
 


### PR DESCRIPTION
Hi,

I've been working on modifying the syngcn to be able to initialize with user-defined embeddings. There is a parameter `-embed` in both syngcn.py and semgcn.py, but only the one in semgcn.py is used. I added some codes to enable initializing syngcn with user-defined embeddings.

In addition, there may be some cases when words in the embedding file contain spaces (in user-defined embeddings), for example some telephone numbers. So I modified the method getEmbedding() in helper.py so that the loading process is more robust.

I have tested the modified codes and it turned out to be ok.

Thanks for your time.
